### PR TITLE
fix setting hostname by removing spaces

### DIFF
--- a/flash
+++ b/flash
@@ -21,11 +21,11 @@ OPTIONS:
 The config file occidentalis.txt should look like
 
 # hostname for your Hypriot Raspberry Pi:
-hostname = hypriot-pi
+hostname=hypriot-pi
 
 # basic wireless networking options:
-wifi_ssid = SSID
-wifi_password = 12345
+wifi_ssid=SSID
+wifi_password=12345
 EOF
 exit 1
 }
@@ -166,15 +166,15 @@ fi
 
 if [ ! -z $SD_HOSTNAME ]; then
   echo "Set hostname = $SD_HOSTNAME"
-  sed -i -e "s/.*hostname.*=.*\$/hostname = $SD_HOSTNAME/" "${boot}/occidentalis.txt"
+  sed -i -e "s/.*hostname.*=.*\$/hostname=$SD_HOSTNAME/" "${boot}/occidentalis.txt"
 fi
 if [ ! -z $WIFI_SSID ]; then
   echo "Set wifi_ssid = $WIFI_SSID"
-  sed -i -e "s/.*wifi_ssid.*=.*\$/wifi_ssid = $WIFI_SSID/" "${boot}/occidentalis.txt"
+  sed -i -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=$WIFI_SSID/" "${boot}/occidentalis.txt"
 fi
 if [ ! -z $WIFI_PASSWORD ]; then
   echo "Set wifi_password = $WIFI_PASSWORD"
-  sed -i -e "s/.*wifi_password.*=.*\$/wifi_password = $WIFI_PASSWORD/" "${boot}/occidentalis.txt"
+  sed -i -e "s/.*wifi_password.*=.*\$/wifi_password=$WIFI_PASSWORD/" "${boot}/occidentalis.txt"
 fi
 
 echo "Unmounting and ejecting ${disk} ..."


### PR DESCRIPTION
Tested with 

```bash
flash --hostname pi5 http://assets.hypriot.com/hypriot-rpi-20150329-140334.img.zip
ssh pi@pi5.local
```