### PR TITLE
Download from https links as well

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -92,7 +92,7 @@ if [ -f "/tmp/${filename}" ]; then
   image=/tmp/${filename}
   echo "Using cached image ${image}"
 else
-  if beginswith http:// "${image}"; then
+  if beginswith http:// "${image}" || beginswith https:// "${image}"; then
     which curl >/dev/null || (echo "Error: curl not found. Aborting" && exit 1)
     echo "Downloading ${image} ..."
     curl -L -o /tmp/image.img.${extension} "${image}"

--- a/Linux/flash
+++ b/Linux/flash
@@ -101,7 +101,7 @@ if [ -f "/tmp/${filename}" ]; then
   image=/tmp/${filename}
   echo "Using cached image ${image}"
 else
-  if beginswith http:// "${image}" ;then
+  if beginswith http:// "${image}" || beginswith https:// "${image}"; then
       which curl 2>/dev/null || error "Error: curl not found. Aborting" 1
       echo "Downloading ${image} ..."
       curl -L -o /tmp/image.img.${extension} "${image}"


### PR DESCRIPTION
I tried to download the official Raspbian LITE SD image with this tool
and found that it does not handle https links.

This PR fixes it.