### PR TITLE
allow whitespaces in WIFI_SSID

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -181,15 +181,15 @@ if [[ -f "${BOOT_CONF}" ]]; then
   sudo cp "${BOOT_CONF}" "${boot}/config.txt"
 fi
 
-if [ ! -z ${SD_HOSTNAME} ]; then
+if [ ! -z "${SD_HOSTNAME}" ]; then
   echo "Set hostname=${SD_HOSTNAME}"
   sed -i "" -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
 fi
-if [ ! -z ${WIFI_SSID} ]; then
+if [ ! -z "${WIFI_SSID}" ]; then
   echo "Set wifi_ssid=${WIFI_SSID}"
   sed -i "" -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
 fi
-if [ ! -z ${WIFI_PASSWORD} ]; then
+if [ ! -z "${WIFI_PASSWORD}" ]; then
   echo "Set wifi_password=${WIFI_PASSWORD}"
   sed -i "" -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
 fi

--- a/Linux/flash
+++ b/Linux/flash
@@ -245,15 +245,15 @@ if [[ -f "${BOOT_CONF}" ]]; then
     sudo cp "${BOOT_CONF}" "${boot}/config.txt"
 fi
 
-if [ ! -z ${SD_HOSTNAME} ]; then
+if [ ! -z "${SD_HOSTNAME}" ]; then
     echo "Set hostname=${SD_HOSTNAME}"
     sudo sed -i -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
 fi
-if [ ! -z ${WIFI_SSID} ]; then
+if [ ! -z "${WIFI_SSID}" ]; then
     echo "Set wifi_ssid=${WIFI_SSID}"
     sudo sed -i -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
 fi
-if [ ! -z ${WIFI_PASSWORD} ]; then
+if [ ! -z "${WIFI_PASSWORD}" ]; then
     echo "Set wifi_password=${WIFI_PASSWORD}"
     sudo sed -i -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
 fi


### PR DESCRIPTION
Hi, this script is really convenient and I like this. But I had a problem.

I have an Wi-Fi access point, named "ham airmac" and the 'flash' script failed to write wifi_ssid setting to config, like below log. So I modified the scripts to allow the situation. I only actually tested Darwin version though.

```
$ flash --ssid "ham airmac" --password "xxxxxx" --hostname hypriot http://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip
....
Is /dev/disk2s1 correct? y
Unmounting disk2 ...
Unmount of all volumes on disk2 was successful
Unmount of all volumes on disk2 was successful
Flashing /tmp/hypriot-rpi-20151115-132854.img to disk2 ...
Password:
1.4GiB 0:00:27 [52.4MiB/s] [==============================================================================================================>] 100%
dd: /dev/rdisk2: Invalid argument
0+22889 records in
0+22888 records out
1499987968 bytes transferred in 27.283941 secs (54976954 bytes/sec)
Set hostname=hypriot
/usr/local/bin/flash: line 188: [: ham: binary operator expected <---------- ERROR!
Set wifi_password=xxxxxxxxxx
Unmounting and ejecting disk2 ...
Unmount of all volumes on disk2 was successful
Unmount of all volumes on disk2 was successful
Disk /dev/disk2 ejected
🍺 Finished.
```