### PR TITLE
Filter correct disk ID in Linux

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -153,7 +153,7 @@ esac
 
 if [[ -z "${disk}" ]]; then
     # try to find the correct disk of the inserted SD card
-    disk=`df | grep /media | cut -f1 -d " " | sed -e 's/[0-9]$//'|sed  -e 's/p.*$//'  | sort | uniq`
+    disk=`df | grep /media | cut -f1 -d " " | sed -e 's/p.*$//' | sed -e 's/[1-9]//' | sort | uniq`
 
     if [[ `echo "${disk}"|awk '{print NF}'` -gt 1 ]]; then
 	PS3='Please pick your device: '
@@ -177,7 +177,7 @@ if [[ -z "${disk}" ]]; then
 	echo "No SD card found. Please insert SD card, I'll wait for it..."
 	while [ "${disk}" == "" ]; do
 	    sleep 1
-	    disk=`df | grep /media | cut -f1 -d " " | sed -e 's/[0-9]//'|sed -e 's/p.*$//'  | sort | uniq`
+	    disk=`df | grep /media | cut -f1 -d " " | sed -e 's/p.*$//' | sed -e 's/[1-9]//' | sort | uniq`
 	done
     fi
 fi


### PR DESCRIPTION
This PR is based on top of the idea of https://github.com/hypriot/flash/pull/21. This PR now correctly selects SD cards with `mmcblk...` identifier as well as USB-SD reader identified via `sdb...` when using the flash tool in Linux.

@firecyberice Please test this on your machine.