### PR TITLE
Check file type instead of extension to run unzip

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -111,7 +111,7 @@ else
     exit 10
   fi
 
-  if endswith .zip "${image}"; then
+  if [[ "$(file ${image})" == *"Zip archive"* ]]; then
     echo "Uncompressing ${image} ..."
     unzip -o "${image}" -d /tmp
     image=$(unzip -l "${image}" | grep --color=never -v Archive: | grep --color=never img | cut -c 30-)

--- a/Linux/flash
+++ b/Linux/flash
@@ -120,7 +120,7 @@ else
       exit 10
   fi
 
-  if endswith .zip "${image}" ;then
+  if [[ "$(file ${image})" == *"Zip archive"* ]]; then
       which unzip 2>/dev/null || error "Error: unzip not found. Aborting" 1
       echo "Uncompressing ${image} ..."
       unzip -o "${image}" -d /tmp


### PR DESCRIPTION
Instead of just checking the file extension of the local file for `.zip` get the file type with the `file` utility and unzip it.

Fixes #28 
