### PR TITLE
Fix the newly extracted filename on OSX

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -114,7 +114,7 @@ else
   if [[ "$(file ${image})" == *"Zip archive"* ]]; then
     echo "Uncompressing ${image} ..."
     unzip -o "${image}" -d /tmp
-    image=$(unzip -l "${image}" | grep --color=never -v Archive: | grep --color=never img | cut -c 30-)
+    image=$(unzip -l "${image}" | grep --color=never -v Archive: | grep --color=never img | cut -c 29-)
     image="/tmp/${image}"
     echo "Use ${image}"
   fi


### PR DESCRIPTION
Rigth now the first character of the filename will be discarded.
This fix repairs it and we do have the full filename instead.

Here is a log, where you can see the problem:
```
flash sd-card-odroid-xu4-dirty.img.zip
Uncompressing sd-card-odroid-xu4-dirty.img.zip ...
Archive:  sd-card-odroid-xu4-dirty.img.zip
  inflating: /tmp/sd-card-odroid-xu4-dirty.img
Use /tmp/d-card-odroid-xu4-dirty.img
```