### PR TITLE
Recognize SD card without FAT partition

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -128,19 +128,19 @@ fi
 
 while true; do
   # try to find the correct disk of the inserted SD card
-  disk=`df | grep --color=never -e "disk[0-9]s1" | grep --color=never Volumes | cut -c 6-10`
+  disk=$(diskutil list | grep --color=never FDisk_partition_scheme | awk 'NF>1{print $NF}')
   if [ "${disk}" == "" ]; then
     echo "No SD card found. Please insert SD card, I'll wait for it..."
     while [ "${disk}" == "" ]; do
       sleep 1
-      disk=`df | grep --color=never -e "disk[0-9]s1" | grep --color=never Volumes | cut -c 6-10`
+      disk=$(diskutil list | grep --color=never FDisk_partition_scheme | awk 'NF>1{print $NF}')
     done
   fi
 
   df -h
   while true; do
     echo ""
-    read -p "Is /dev/${disk}s1 correct? " yn
+    read -p "Is /dev/${disk} correct? " yn
     case $yn in
       [Yy]* ) break;;
       [Nn]* ) exit;;
@@ -151,8 +151,8 @@ while true; do
   echo "Unmounting ${disk} ..."
   diskutil unmountDisk /dev/${disk}s1
   diskutil unmountDisk /dev/${disk}
-  writable=$(ls -l /dev/${disk}s1 | cut -c 3)
-  if [ "$writable" == "w" ]; then
+  readonlymedia=$(diskutil info "/dev/${disk}" | grep "Read-Only Media" | awk 'NF>1{print $NF}')
+  if [ "$readonlymedia" == "No" ]; then
     break
   else
     afplay /System/Library/Sounds/Basso.aiff
@@ -173,35 +173,43 @@ else
   sudo dd bs=1m if=${image} of=/dev/r${disk}
 fi
 
-boot=$(df | grep --color=never /dev/${disk}s1 | sed 's,.*/Volumes,/Volumes,')
+boot=$(df | grep --color=never "/dev/${disk}s1" | sed 's,.*/Volumes,/Volumes,')
 if [ "${boot}" == "" ]; then
-  while [ "${boot}" == "" ]; do
+  COUNTER=0
+  while [ $COUNTER -lt 5 ]; do
     sleep 1
-    boot=$(df | grep --color=never /dev/${disk}s1 | sed 's,.*/Volumes,/Volumes,')
+    boot=$(df | grep --color=never "/dev/${disk}s1" | sed 's,.*/Volumes,/Volumes,')
+    if [ "${boot}" != "" ]; then
+      break
+    fi
+    let COUNTER=COUNTER+1
   done
 fi
 
-if [ -f "${OCCI_CONFIG}" ]; then
-  echo "Copying ${OCCI_CONFIG} to ${boot}/occidentalis.txt ..."
-  cp "${OCCI_CONFIG}"  "${boot}/occidentalis.txt"
-fi
+# customize for first boot
+if [ "${boot}" ]; then
+  if [ -f "${OCCI_CONFIG}" ]; then
+    echo "Copying ${OCCI_CONFIG} to ${boot}/occidentalis.txt ..."
+    cp "${OCCI_CONFIG}"  "${boot}/occidentalis.txt"
+  fi
 
-if [[ -f "${BOOT_CONF}" ]]; then
-  echo "Copying ${BOOT_CONF} to ${boot}/config.txt ..."
-  sudo cp "${BOOT_CONF}" "${boot}/config.txt"
-fi
+  if [[ -f "${BOOT_CONF}" ]]; then
+    echo "Copying ${BOOT_CONF} to ${boot}/config.txt ..."
+    sudo cp "${BOOT_CONF}" "${boot}/config.txt"
+  fi
 
-if [ ! -z "${SD_HOSTNAME}" ]; then
-  echo "Set hostname=${SD_HOSTNAME}"
-  sed -i "" -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
-fi
-if [ ! -z "${WIFI_SSID}" ]; then
-  echo "Set wifi_ssid=${WIFI_SSID}"
-  sed -i "" -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
-fi
-if [ ! -z "${WIFI_PASSWORD}" ]; then
-  echo "Set wifi_password=${WIFI_PASSWORD}"
-  sed -i "" -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
+  if [ ! -z "${SD_HOSTNAME}" ]; then
+    echo "Set hostname=${SD_HOSTNAME}"
+    sed -i "" -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
+  fi
+  if [ ! -z "${WIFI_SSID}" ]; then
+    echo "Set wifi_ssid=${WIFI_SSID}"
+    sed -i "" -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
+  fi
+  if [ ! -z "${WIFI_PASSWORD}" ]; then
+    echo "Set wifi_password=${WIFI_PASSWORD}"
+    sed -i "" -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
+  fi
 fi
 
 echo "Unmounting and ejecting ${disk} ..."


### PR DESCRIPTION
Fixes #38 recognize SD card without FAT partition
fixes #29 work with mounted .dmg files

Doesn't "hang" after flashing an SD card image without FAT partition, just abort after 5 seconds and unmount everything without occidentalis.txt/config.txt features.
