### PR TITLE
Use cache only for downloads, always extract ZIP

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -88,8 +88,8 @@ filename=$(basename "${image}")
 extension="${filename##*.}"
 filename="${filename%.*}"
 
-if [ -f "/tmp/${filename}" ]; then
-  image=/tmp/${filename}
+if [ -f "/tmp/${filename}.${extension}" ]; then
+  image=/tmp/${filename}.${extension}
   echo "Using cached image ${image}"
 else
   if beginswith http:// "${image}" || beginswith https:// "${image}"; then


### PR DESCRIPTION
Flashing one of our locally built sd-card-*-dirty.img.zip files from the hypriot/image-builder-* repos lead in a caching problem.
This PR fixes it by always extracting the ZIP file.