### PR TITLE
Use absolute path to sed to avoid gnu-sed

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -188,12 +188,12 @@ else
   sudo /bin/dd bs=1m if=${image} of=/dev/r${disk}
 fi
 
-boot=$(df | grep --color=never "/dev/${disk}s1" | sed 's,.*/Volumes,/Volumes,')
+boot=$(df | grep --color=never "/dev/${disk}s1" | /usr/bin/sed 's,.*/Volumes,/Volumes,')
 if [ "${boot}" == "" ]; then
   COUNTER=0
   while [ $COUNTER -lt 5 ]; do
     sleep 1
-    boot=$(df | grep --color=never "/dev/${disk}s1" | sed 's,.*/Volumes,/Volumes,')
+    boot=$(df | grep --color=never "/dev/${disk}s1" | /usr/bin/sed 's,.*/Volumes,/Volumes,')
     if [ "${boot}" != "" ]; then
       break
     fi
@@ -221,7 +221,7 @@ if [ "${boot}" ]; then
   if [ -f "${boot}/device-init.yaml" ]; then
     if [ ! -z "${SD_HOSTNAME}" ]; then
       echo "Set hostname=${SD_HOSTNAME}"
-      sed -i "" -e "s/.*hostname:.*\$/hostname: ${SD_HOSTNAME}/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*hostname:.*\$/hostname: ${SD_HOSTNAME}/" "${boot}/device-init.yaml"
     fi
   fi
 
@@ -229,15 +229,15 @@ if [ "${boot}" ]; then
   if [ -f "${boot}/occidentalis.txt" ]; then
     if [ ! -z "${SD_HOSTNAME}" ]; then
       echo "Set hostname=${SD_HOSTNAME}"
-      sed -i "" -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
+      /usr/bin/sed -i "" -e "s/.*hostname.*=.*\$/hostname=${SD_HOSTNAME}/" "${boot}/occidentalis.txt"
     fi
     if [ ! -z "${WIFI_SSID}" ]; then
       echo "Set wifi_ssid=${WIFI_SSID}"
-      sed -i "" -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
+      /usr/bin/sed -i "" -e "s/.*wifi_ssid.*=.*\$/wifi_ssid=${WIFI_SSID}/" "${boot}/occidentalis.txt"
     fi
     if [ ! -z "${WIFI_PASSWORD}" ]; then
       echo "Set wifi_password=${WIFI_PASSWORD}"
-      sed -i "" -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
+      /usr/bin/sed -i "" -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
     fi
   fi
 fi


### PR DESCRIPTION
Use an absolute path to sed to avoid problems if the GNU sed binary is installed on a Mac.

Fixes #48