### PR TITLE
Fix Markdown errors and add wget install on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,39 @@
 # flash
+
 Command line script to flash SD card images for the Raspberry Pi.
 
 The typical workflow looks like this:
 
 [![asciicast](https://asciinema.org/a/4k72pounxxybtix84ecl4b69w.png)](https://asciinema.org/a/4k72pounxxybtix84ecl4b69w)
 
-1. Run `flash http://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip`
-2. Insert SD card to your notebook
-3. Press RETURN
-4. Eject SD card and insert it to your Raspberry Pi - done!
-
+1.  Run `flash http://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip`
+2.  Insert SD card to your notebook
+3.  Press RETURN
+4.  Eject SD card and insert it to your Raspberry Pi - done!
 
 This script can
 
-* download a compressed SD card from the internet or from S3
-* use a local SD card image, either compressed or uncompressed
-* wait until a SD card is plugged in
-* search for a SD card plugged into your Computer
-* show progress bar while flashing (if `pv` is installed)
-* copy an optional `occidentalis.txt` file into the boot partition of the SD image
-* copy an optional `config.txt` file into the boot partition of the SD image
-* optional set the hostname of this SD image
-* optional set the WiFi settings as well
-* play a little sound after flashing
-* unplugs the SD card
+*   download a compressed SD card from the internet or from S3
+*   use a local SD card image, either compressed or uncompressed
+*   wait until a SD card is plugged in
+*   search for a SD card plugged into your Computer
+*   show progress bar while flashing (if `pv` is installed)
+*   copy an optional `occidentalis.txt` file into the boot partition of the SD
+*   copy an optional `config.txt` file into the boot partition of the SD image
+*   optional set the hostname of this SD image
+*   optional set the WiFi settings as well
+*   play a little sound after flashing
+*   unplugs the SD card
 
 At the moment only Mac OS X and Linux is supported.
 
 ## Installation
+
+For the Mac you will have to install `wget` first
+
+```bash
+brew install wget
+```
 
 Download the appropriate version for Linux or Mac with this command
 
@@ -41,10 +47,10 @@ sudo mv flash /usr/local/bin/flash
 
 The `flash` script needs optional tools
 
-* `curl` - if you want to flash directly with an HTTP URL
-* `aws` - if you want to flash directly from an AWS S3 bucket
-* `pv` - to see a progress bar while flashing with the `dd` command
-* `unzip` - to extract zip files.
+*   `curl` - if you want to flash directly with an HTTP URL
+*   `aws` - if you want to flash directly from an AWS S3 bucket
+*   `pv` - to see a progress bar while flashing with the `dd` command
+*   `unzip` - to extract zip files.
 
 #### Mac
 
@@ -62,7 +68,7 @@ sudo pip install awscli
 
 ## Usage
 
-```
+```bash
 $ flash --help
 usage: flash [options] name-of-rpi.img
 
@@ -81,7 +87,7 @@ OPTIONS:
 
 This is a complete download and flash cycle with all its steps.
 
-```
+```shell
 $ flash http://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip
 Downloading http://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip ...
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -118,15 +124,21 @@ Disk /dev/disk2 ejected
 
 ## occidentalis.txt
 
-**WARNING** The following option will change in the near future as we are switching from our RPi-only SD card image to new debian based SD images for different devices. To support all other devices there will be a different file to do similar tasks and we have more functions in mind.
+**WARNING** The following option will change in the near future as we are
+switching from our RPi-only SD card image to new debian based SD images for
+different devices. To support all other devices there will be a different file
+to do similar tasks and we have more functions in mind.
 
-The option `--config` could be used to copy a `occidentalis.txt` into the SD image before it is unplugged.
+The option `--config` could be used to copy a `occidentalis.txt` into the SD
+image before it is unplugged.
 
-Many kudos to [Adafruit's occi](https://github.com/adafruit/Adafruit-Occi) package that handles updating hostname and WiFi settings while booting the Raspberry Pi.
+Many kudos to [Adafruit's occi](https://github.com/adafruit/Adafruit-Occi)
+package that handles updating hostname and WiFi settings while booting the
+Raspberry Pi.
 
 The config file `occidentalis.txt` should look like
 
-```
+```bash
 # hostname for your Hypriot Raspberry Pi:
 hostname=hypriot-pi
 
@@ -137,13 +149,16 @@ wifi_password=12345
 
 ## config.txt
 
-The option `--bootconf` can be used to copy a `config.txt` into the SD image before it is unplugged.
+The option `--bootconf` can be used to copy a `config.txt` into the SD image
+before it is unplugged.
 
-With this option it is possible to change some memory, camera, video settings etc. See the [config.txt documentation ](https://www.raspberrypi.org/documentation/configuration/config-txt.md) at raspberrypi.org for more details.
+With this option it is possible to change some memory, camera, video settings
+etc. See the [config.txt documentation](https://www.raspberrypi.org/documentation/configuration/config-txt.md)
+at raspberrypi.org for more details.
 
 The boot config file config.txt has name/value pairs such as:
 
-```
+```bash
 max_usb_current=1
 hdmi_force_hotplug=1
 ```
@@ -170,7 +185,8 @@ This works only for SD card images that already have `occi` installed.
 flash --hostname mypi hypriot.img
 ```
 
-Then unplug the SD card from your computer, plug it into your Pi and boot your Pi. After a while the Pi can be found via Bonjour/avahi and you can log in with
+Then unplug the SD card from your computer, plug it into your Pi and boot your
+Pi. After a while the Pi can be found via Bonjour/avahi and you can log in with
 
 ```bash
 ssh pi@mypi.local
@@ -178,14 +194,21 @@ ssh pi@mypi.local
 
 ## Development
 
-Pull requests and other feedback is always welcome. The `flash` tool should fit our all needs and environments.
+Pull requests and other feedback is always welcome. The `flash` tool should fit
+our all needs and environments.
 
 ### Test Linux from Mac
 
-As I only have a MacBookPro where I started to develop the `flash` tool it is hard for me to test Linux issues. But with some help I found a way to spin up a VirtualBox Vagrant box with Ubuntu that maps the internal Apple SD card reader into the VM. Thanks to [Flexshot](https://github.com/Flexshot) for the helper functions I found in [NextThingCo/CHIP-SDK#15](https://github.com/NextThingCo/CHIP-SDK/pull/15).
+As I only have a MacBookPro where I started to develop the `flash` tool it is
+hard for me to test Linux issues. But with some help I found a way to spin up a
+VirtualBox Vagrant box with Ubuntu that maps the internal Apple SD card reader
+into the VM. Thanks to [Flexshot](https://github.com/Flexshot) for the helper
+functions I found in [NextThingCo/CHIP-SDK#15](https://github.com/NextThingCo/CHIP-SDK/pull/15).
 
-Check the vendor ID and product ID in "About this Mac" -> System Report ... -> Card Reader. I found the vendor ID 0x05ac and product ID 0x8406 can be found in the `Vagrantfile`.
+Check the vendor ID and product ID in "About this Mac" -> System Report ... ->
+Card Reader. I found the vendor ID 0x05ac and product ID 0x8406 can be found in
+the `Vagrantfile`.
 
-```
+```bash
 vagrant up --provider virtualbox
 ```


### PR DESCRIPTION
Fix markdown errors as identified by atom-linter 
See https://atom.io/packages/linter-markdown
Add wget install for those on a Mac