### PR TITLE
Remove unnecessary udevadm settle

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -237,8 +237,6 @@ fi
 
 echo "Mounting ${dev} to customize..."
 sudo mount "${dev}" "${boot}"
-echo "Waiting for device..."
-udevadm settle
 
 if [ -f "${CONFIG_FILE}" ]; then
   if [[ "${CONFIG_FILE}" == *"occi"* ]]; then


### PR DESCRIPTION
Device paths won't change after being mounted, so udev has nothing to
do. Aside from when we change the partition table via dd, we don't need
to do udevadm settles.