### PR TITLE
Set the wlan0 ssid and password in device-init.yaml if given

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -231,13 +231,13 @@ if [ "${boot}" ]; then
     fi
     if [ ! -z "${WIFI_SSID}" ]; then
       echo "Set wlan0/ssid=${WIFI_SSID}"
-      /usr/bin/sed -i "" -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
-      /usr/bin/sed -i "" -e "s/.*ssid:.*=.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*wlan0:.*\$/    wlan0:/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*ssid:.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
     fi
     if [ ! -z "${WIFI_PASSWORD}" ]; then
       echo "Set wlan0/password=${WIFI_PASSWORD}"
-      /usr/bin/sed -i "" -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
-      /usr/bin/sed -i "" -e "s/.*password:.*=.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*wlan0:.*\$/    wlan0:/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*password:.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
     fi
   fi
 

--- a/Darwin/flash
+++ b/Darwin/flash
@@ -23,7 +23,11 @@ For HypriotOS devices:
 The config file device-init.yaml should look like
 
 hostname: black-pearl
-
+wifi:
+  interfaces:
+    wlan0:
+      ssid: "MyNetwork"
+      password: "secret_password"
 
 For Raspberry Pi until Hector release:
 
@@ -224,6 +228,16 @@ if [ "${boot}" ]; then
     if [ ! -z "${SD_HOSTNAME}" ]; then
       echo "Set hostname=${SD_HOSTNAME}"
       /usr/bin/sed -i "" -e "s/.*hostname:.*\$/hostname: ${SD_HOSTNAME}/" "${boot}/device-init.yaml"
+    fi
+    if [ ! -z "${WIFI_SSID}" ]; then
+      echo "Set wlan0/ssid=${WIFI_SSID}"
+      /usr/bin/sed -i "" -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*ssid:.*=.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
+    fi
+    if [ ! -z "${WIFI_PASSWORD}" ]; then
+      echo "Set wlan0/password=${WIFI_PASSWORD}"
+      /usr/bin/sed -i "" -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
+      /usr/bin/sed -i "" -e "s/.*password:.*=.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
     fi
   fi
 

--- a/Linux/flash
+++ b/Linux/flash
@@ -34,7 +34,11 @@ For HypriotOS devices:
 The config file device-init.yaml should look like
 
 hostname: black-pearl
-
+wifi:
+  interfaces:
+    wlan0:
+      ssid: "MyNetwork"
+      password: "secret_password"
 
 For Raspberry Pi until Hector release:
 
@@ -259,6 +263,16 @@ if [ -f "${boot}/device-init.yaml" ]; then
   if [ ! -z "${SD_HOSTNAME}" ]; then
     echo "Set hostname=${SD_HOSTNAME}"
     sudo sed -i -e "s/.*hostname:.*\$/hostname: ${SD_HOSTNAME}/" "${boot}/device-init.yaml"
+  fi
+  if [ ! -z "${WIFI_SSID}" ]; then
+    echo "Set wlan0/ssid=${WIFI_SSID}"
+    /usr/bin/sed -i -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*ssid:.*=.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
+  fi
+  if [ ! -z "${WIFI_PASSWORD}" ]; then
+    echo "Set wlan0/password=${WIFI_PASSWORD}"
+    /usr/bin/sed -i -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*password:.*=.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
   fi
 fi
 

--- a/Linux/flash
+++ b/Linux/flash
@@ -266,13 +266,13 @@ if [ -f "${boot}/device-init.yaml" ]; then
   fi
   if [ ! -z "${WIFI_SSID}" ]; then
     echo "Set wlan0/ssid=${WIFI_SSID}"
-    /usr/bin/sed -i -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
-    /usr/bin/sed -i -e "s/.*ssid:.*=.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*wlan0:.*\$/    wlan0:/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*ssid:.*\$/      ssid: \"${WIFI_SSID}\"/" "${boot}/device-init.yaml"
   fi
   if [ ! -z "${WIFI_PASSWORD}" ]; then
     echo "Set wlan0/password=${WIFI_PASSWORD}"
-    /usr/bin/sed -i -e "s/.*wlan0:.*=.*\$/    wlan0:/" "${boot}/device-init.yaml"
-    /usr/bin/sed -i -e "s/.*password:.*=.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*wlan0:.*\$/    wlan0:/" "${boot}/device-init.yaml"
+    /usr/bin/sed -i -e "s/.*password:.*\$/      password: \"${WIFI_PASSWORD}\"/" "${boot}/device-init.yaml"
   fi
 fi
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This script can
 *   wait until a SD card is plugged in
 *   search for a SD card plugged into your Computer
 *   show progress bar while flashing (if `pv` is installed)
-*   copy an optional `occidentalis.txt` file into the boot partition of the SD
+*   copy an optional `device-init.yaml` or `occidentalis.txt` file into the boot partition of the SD
 *   copy an optional `config.txt` file into the boot partition of the SD image
 *   optional set the hostname of this SD image
 *   optional set the WiFi settings as well
@@ -77,7 +77,7 @@ Flash a local or remote Raspberry Pi SD card image.
 OPTIONS:
    --help|-h      Show this message
    --bootconf|-C  Copy this config file to /boot/config.txt
-   --config|-c    Copy this config file to /boot/occidentalis.txt
+   --config|-c    Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
    --hostname|-n  Set hostname for this SD image
    --ssid|-s      Set WiFi SSID for this SD image
    --password|-p  Set WiFI password for this SD image
@@ -121,6 +121,25 @@ Unmount of all volumes on disk2 was successful
 Disk /dev/disk2 ejected
 🍺  Finished.
 ```
+
+## device-init.yaml
+
+The option `--config` could be used to copy a `device-init.yaml` into the SD
+image before it is unplugged. This YAML file can be read by newer HyperiotOS
+SD images.
+
+The config file device-init.yaml should look like
+
+```yaml
+hostname: black-pearl
+wifi:
+  interfaces:
+    wlan0:
+      ssid: "MyNetwork"
+      password: "secret_password"
+```
+
+If you don't want to set any wifi settings, comment out or remove the wlan0, ssid and password.
 
 ## occidentalis.txt
 


### PR DESCRIPTION
This PR with hypriot/image-builder-rpi#55 enables setting the wifi ssid and password for newer HypriotOS SD card images. The /boot/device-init.yaml file in the SD card image must be prepared with a wlan0 setting that can be enabled by the flash tool.

Fixes #58