### PR TITLE
Fixed mount complaint on Linux

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -243,7 +243,7 @@ else
 fi
 
 echo "Mounting ${dev} to customize..."
-sudo mount "${dev}" "${boot}"
+sudo mount -t vfat "${dev}" "${boot}"
 
 if [ -f "${CONFIG_FILE}" ]; then
   if [[ "${CONFIG_FILE}" == *"occi"* ]]; then


### PR DESCRIPTION
Ran into problem with flash command recently where it was unable to finish customizing the image.

I got the following on the command line:

```
Mounting /dev/mmcblk0p1 to customize...
mount: you must specify the filesystem type
```

Not sure why I've just started seeing it, but this seems to fix it.
