### PR TITLE
Added filesystem autodetect in case of non-vfat boot

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -243,7 +243,7 @@ else
 fi
 
 echo "Mounting ${dev} to customize..."
-FS_TYPE=$(sudo blkid -o value -s TYPE "${dev}")
+FS_TYPE=$(sudo blkid -o value -s TYPE "${dev}" || echo vfat)
 sudo mount -t ${FS_TYPE} "${dev}" "${boot}"
 
 if [ -f "${CONFIG_FILE}" ]; then

--- a/Linux/flash
+++ b/Linux/flash
@@ -243,7 +243,8 @@ else
 fi
 
 echo "Mounting ${dev} to customize..."
-sudo mount -t vfat "${dev}" "${boot}"
+FS_TYPE=$(sudo blkid -o value -s TYPE "${dev}")
+sudo mount -t ${FS_TYPE} "${dev}" "${boot}"
 
 if [ -f "${CONFIG_FILE}" ]; then
   if [[ "${CONFIG_FILE}" == *"occi"* ]]; then


### PR DESCRIPTION
Ran into this issue when trying to flash the ODROID ext4 only image. This should make it more flexible as long as `blkid` is an OK dependency. 