### PR TITLE
Clarifying Linux distros instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ brew install pv
 brew install awscli
 ```
 
-#### Linux
+#### Linux (Debian/Ubuntu)
 
 ```bash
 sudo apt-get install -y pv curl python-pip unzip hdparm


### PR DESCRIPTION
As different Linux distributions have the different methods of software installation, this PR clarifies that the described method is specific for Debian/Ubuntu-based distributions.