### PR TITLE
Update README.md usage section to include clusterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ OPTIONS:
    --hostname|-n  Set hostname for this SD image
    --ssid|-s      Set WiFi SSID for this SD image
    --password|-p  Set WiFI password for this SD image
+   --clusterlab|-l Start Cluster-Lab on boot: true or false
+   --device|-d    Card Device
+
 ```
 
 ## How it looks like


### PR DESCRIPTION
Low hanging fruit. The `--help` output of the `Usage` section does not include the clusterlab flag. This pull request adds the current output from running `./flash --help`.