### PR TITLE
Fixes typo in error message

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -275,5 +275,5 @@ if [ $? -eq 0 ]; then
   echo "🍺  Finished."
 else
   afplay /System/Library/Sounds/Basso.aiff
-  echo "👎  Someting went wrong."
+  echo "👎  Something went wrong."
 fi


### PR DESCRIPTION
Fixes a small typo when the flashing is unsuccessful.