### PR TITLE
Update flash to allow concurrent runs

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -235,7 +235,7 @@ udevadm settle
 sudo hdparm -z "${disk}"
 
 echo "Mounting Disk"
-boot=/tmp/mnt
+boot=/tmp/mnt.$$
 mkdir -p ${boot}
 
 if beginswith /dev/mmcblk "${disk}" ;then
@@ -311,6 +311,7 @@ do
 done
 
 if [ $? -eq 0 ]; then
+  rmdir ${boot}
   echo "Finished."
 else
   echo "Something went wrong."


### PR DESCRIPTION
This sets the `${boot}` temporary mount point based upon the PID of the flash instance which is running. This allows for more than one instance to run at the same time. Additionally, on successful run it removes the temporary mount point.

This helps reduce the pain of flashing a cluster ;-)