### PR TITLE
fail early when url is malformed or the server return an error code

### DIFF
--- a/Darwin/flash
+++ b/Darwin/flash
@@ -148,7 +148,7 @@ else
   if beginswith http:// "${image}" || beginswith https:// "${image}"; then
     which curl >/dev/null || (echo "Error: curl not found. Aborting" && exit 1)
     echo "Downloading ${image} ..."
-    curl -L -o "/tmp/image.img.${extension}" "${image}"
+    curl -L --fail -o "/tmp/image.img.${extension}" "${image}"
     image=/tmp/image.img.${extension}
   fi
 

--- a/Linux/flash
+++ b/Linux/flash
@@ -167,7 +167,7 @@ else
   if beginswith http:// "${image}" || beginswith https:// "${image}"; then
     which curl 2>/dev/null || error "Error: curl not found. Aborting" 1
     echo "Downloading ${image} ..."
-    curl -L -o "/tmp/image.img.${extension}" "${image}"
+    curl -L --fail -o "/tmp/image.img.${extension}" "${image}"
     image=/tmp/image.img.${extension}
   fi
 


### PR DESCRIPTION
When a user provided a malformed url or the server return a file "Not Found" error, the script continued to execute.
the --fail option passed to curl prevent this behavior and result in a proper error handling.

have a look at the following example:
```
./flash --hostname node01 https://github.com/hypriot/image-builder-rpi/releases/download/v1.4.0/hypriotos-rpi-v1.4.0.im
/usr/bin/curl
Downloading https://github.com/hypriot/image-builder-rpi/releases/download/v1.4.0/hypriotos-rpi-v1.4.0.im ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
```