### PR TITLE
Remove assumed of location of bash

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Flash Raspberry Pi SD card images on your Mac
 # Stefan Scherer - scherer_stefan@icloud.com
 #


### PR DESCRIPTION
A tiny fix which allows the script to work on systems which don't install bash in `/bin/bash`.

Thanks for such a great tool.