### PR TITLE
Added support for loop device partitions

### DIFF
--- a/Linux/flash
+++ b/Linux/flash
@@ -277,6 +277,8 @@ mkdir -p ${boot}
 
 if beginswith /dev/mmcblk "${disk}" ;then
   dev="${disk}p1"
+elif beginswith /dev/loop "${disk}" ;then
+  dev="${disk}p1"
 else
   dev="${disk}1"
 fi


### PR DESCRIPTION
Simple patch for partition naming scheme on loop devices (e.g. /dev/loop0p1). I might later make a patch which handles creating the loop device automatically when a non-/dev/ location is provided.


Fixes #102 
