### PR TITLE
Improve README and add samples

### DIFF
--- a/sample/no-uart-config.txt
+++ b/sample/no-uart-config.txt
@@ -1,0 +1,10 @@
+hdmi_force_hotplug=1
+enable_uart=0
+
+# camera settings, see http://elinux.org/RPiconfig#Camera
+start_x=1
+disable_camera_led=1
+gpu_mem=128
+
+# Enable audio (added by raspberrypi-sys-mods)
+dtparam=audio=on

--- a/sample/wifi-device-init.yml
+++ b/sample/wifi-device-init.yml
@@ -1,0 +1,12 @@
+# hostname for your HypriotOS device
+hostname: pi0w
+# optional wireless network settings
+# To make wifi work with RPi3 and RPi0
+# you also have to set "enable_uart=0" in config.txt
+# See no-uart-config.txt for an example.
+#
+wifi:
+  interfaces:
+    wlan0:
+      ssid: "YourSSID"
+      password: "YourSecretPreSharedKey"

--- a/sample/wifi-user-data.yml
+++ b/sample/wifi-user-data.yml
@@ -1,0 +1,75 @@
+#cloud-config
+# vim: syntax=yaml
+#
+
+# The current version of cloud-init in the Hypriot rpi-64 is 0.7.9
+# When dealing with cloud-init, it is SUPER important to know the version
+# I have wasted many hours creating servers to find out the module I was trying to use wasn't in the cloud-init version I had
+# Documentation: http://cloudinit.readthedocs.io/en/0.7.9/index.html
+
+# Set your hostname here, the manage_etc_hosts will update the hosts file entries as well
+hostname: pi3
+manage_etc_hosts: true
+
+# You could modify this for your own user information
+users:
+  - name: pirate
+    gecos: "Hypriot Pirate"
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    groups: users,docker,video
+    plain_text_passwd: hypriot
+    lock_passwd: false
+    ssh_pwauth: true
+    chpasswd: { expire: false }
+
+# # Set the locale of the system
+# locale: "en_US.UTF-8"
+
+# # Set the timezone
+# # Value of 'timezone' must exist in /usr/share/zoneinfo
+# timezone: "America/Los_Angeles"
+
+# # Update apt packages on first boot
+# package_update: true
+# package_upgrade: true
+# package_reboot_if_required: true
+package_upgrade: false
+
+# # Install any additional apt packages you need here
+# packages:
+#  - ntp
+
+# # WiFi connect to HotSpot
+# To make wifi work with RPi3 and RPi0
+# you also have to set "enable_uart=0" in config.txt
+# See no-uart-config.txt for an example.
+#
+# # - use `wpa_passphrase SSID PASSWORD` to encrypt the psk
+write_files:
+  - content: |
+      allow-hotplug wlan0
+      iface wlan0 inet dhcp
+      wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
+      iface default inet dhcp
+    path: /etc/network/interfaces.d/wlan0
+  - content: |
+      ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+      update_config=1
+      network={
+      ssid="YourSSID"
+      psk="YourSecretPreSharedKey"
+      proto=RSN
+      key_mgmt=WPA-PSK
+      pairwise=CCMP
+      auth_alg=OPEN
+      }
+    path: /etc/wpa_supplicant/wpa_supplicant.conf
+
+# These commands will be ran once on first boot only
+runcmd:
+  # Pickup the hostname changes
+  - 'systemctl restart avahi-daemon'
+
+  # Activate WiFi interface
+  - 'ifup wlan0'


### PR DESCRIPTION
- Describe the cloud-init config with user-data
- Add samples folder for onboard WiFi (cloud-init and device-init) and config.txt to turn off UART
- Remove occidentalis sample, remove AWS S3 sample
- Add more details about local development
