### PR TITLE
Use npm test in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ script:
   - brew install shellcheck
   - brew install pv
   - shellcheck Darwin/flash Linux/flash
-  - node_modules/.bin/bats --tap test
+  - npm test


### PR DESCRIPTION
Use the much cleaner `npm test` instead of `node_modules/.bin/bats --tap test` in Travis build.