### PR TITLE
Fix grep returning error

### DIFF
--- a/flash
+++ b/flash
@@ -314,7 +314,7 @@ case "${OSTYPE}" in
     #
     # @return _RET the name of the device to use
     autodetect_device() {
-      _RET=$(lsblk -n -o NAME -d | grep mmcblk)
+      _RET=$(lsblk -n -o NAME -d | grep mmcblk || true)
     }
 
     # Show in the standard output the devices that are a likely


### PR DESCRIPTION
Fix error return of grep when no mmcblk device can be found.