### PR TITLE
[#118]Change block device with path for Linux OS

### DIFF
--- a/flash
+++ b/flash
@@ -314,7 +314,7 @@ case "${OSTYPE}" in
     #
     # @return _RET the name of the device to use
     autodetect_device() {
-      _RET=$(lsblk -n -o NAME -d | grep mmcblk || true)
+      _RET=$(lsblk -p -n -o NAME -d | grep mmcblk || true)
     }
 
     # Show in the standard output the devices that are a likely


### PR DESCRIPTION
Block device is not displayed in Linux OS so processing can not be completed.So, Change block device with path for Linux OS