### PR TITLE
Fix linux test, add udev package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ loo
 *.dmg
 wifi.yml
 flash-wifi.sh
+flash.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY package.json .
 RUN npm install && \
     mv node_modules ..
 
-RUN apt-get update && apt-get install -y sudo pv curl unzip shellcheck
+RUN apt-get update && apt-get install -y sudo pv curl unzip shellcheck udev
 RUN useradd user && \
     mkdir -p /home/user && \
     chown user:users /home/user && \


### PR DESCRIPTION
This fixes the broken CircleCI tests running in Linux containers.
Add the missing `udev` package.
