### PR TITLE
Set date/time in cloud-init runcmd module as part on initial boot

### DIFF
--- a/flash
+++ b/flash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+689#!/usr/bin/env bash
 # Flash Raspberry Pi SD card images on your PC or Mac
 # Stefan Scherer - scherer_stefan@icloud.com
 #
@@ -485,9 +485,9 @@ esac
 add_datetime() {
   # args: $1: full path name of `user-data` file on ssd
   # get current UTC date/time
-  current_datetime=`date -u`
+  current_datetime=$(date -u)
 
-  ed $1 <<EOF
+  ed "$1" <<EOF
   /^runcmd:/
   a
   - date -s "$current_datetime"
@@ -680,13 +680,13 @@ mount_boot_disk "${disk}" "${boot}"
     echo "Copying cloud-init ${USER_DATA} to ${boot}/user-data ..."
     cp "${USER_DATA}" "${boot}/user-data"
     # Hack to set date in a reasonable range to make apt-get update work
-    if ! grep -q "^runcmd:" ${boot}/user-data; then
+    if ! grep -q "^runcmd:" "${boot}"/user-data; then
       # USER_DATA doesn't have a runcmd section, add it
-      echo "" >> ${boot}/user-data
-      echo "runcmd:" >> ${boot}/user-data
+      echo "" >> "${boot}"/user-data
+      echo "runcmd:" >> "${boot}"/user-data
     fi
     # Set date/time as first command in `runcmd` section
-    add_datetime ${boot}/user-data
+    add_datetime "${boot}"/user-data
   fi
 
   if [ -f "${META_DATA}" ]; then

--- a/flash
+++ b/flash
@@ -482,6 +482,21 @@ case "${OSTYPE}" in
     ;;
 esac
 
+add_datetime() {
+  # args: $1: full path name of `user-data` file on ssd
+  # get current UTC date/time
+  current_datetime=`date -u`
+
+  ed $1 <<EOF
+  /^runcmd:/
+  a
+  - date -s "$current_datetime"
+.
+w
+q
+EOF
+}
+
 if endswith Microsoft "$(uname -r)"; then
   echo This script does not work in WSL.
   exit 11
@@ -664,6 +679,14 @@ mount_boot_disk "${disk}" "${boot}"
   if [ -f "${USER_DATA}" ]; then
     echo "Copying cloud-init ${USER_DATA} to ${boot}/user-data ..."
     cp "${USER_DATA}" "${boot}/user-data"
+    # Hack to set date in a reasonable range to make apt-get update work
+    if ! grep -q "^runcmd:" ${boot}/user-data; then
+      # USER_DATA doesn't have a runcmd section, add it
+      echo "" >> ${boot}/user-data
+      echo "runcmd:" >> ${boot}/user-data
+    fi
+    # Set date/time as first command in `runcmd` section
+    add_datetime ${boot}/user-data
   fi
 
   if [ -f "${META_DATA}" ]; then

--- a/flash
+++ b/flash
@@ -487,15 +487,12 @@ add_datetime() {
   # get current UTC date/time
   current_datetime=$(date -u)
 
-  ed "$1" <<EOF
-  /^bootcmd:.*/
-  a
-  - [ cloud-init-per, once, sdate_msg, echo, "Setting initial date/time to: $current_datetime" ]
-  - [ cloud-init-per, once, sdate, date, -s, "$current_datetime" ]
-.
-w
-q
-EOF
+  /usr/bin/sed -i .bak -e \
+  "/^bootcmd/a\\
+  \ \ - [ cloud-init-per, once, sdate_msg, echo, \"Setting initial date/time to: $current_datetime\" ]" \
+  -e "/^bootcmd/a\\
+  \ \ - [ cloud-init-per, once, sdate, date, -s, \"$current_datetime\" ]" $1 &&
+  rm $1.bak
 }
 
 if endswith Microsoft "$(uname -r)"; then

--- a/flash
+++ b/flash
@@ -491,8 +491,8 @@ add_datetime() {
   "/^bootcmd/a\\
   \ \ - [ cloud-init-per, once, sdate_msg, echo, \"Setting initial date/time to: $current_datetime\" ]" \
   -e "/^bootcmd/a\\
-  \ \ - [ cloud-init-per, once, sdate, date, -s, \"$current_datetime\" ]" $1 &&
-  rm $1.bak
+  \ \ - [ cloud-init-per, once, sdate, date, -s, \"$current_datetime\" ]" "$1" &&
+  rm "$1".bak
 }
 
 if endswith Microsoft "$(uname -r)"; then

--- a/flash
+++ b/flash
@@ -1,4 +1,4 @@
-689#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Flash Raspberry Pi SD card images on your PC or Mac
 # Stefan Scherer - scherer_stefan@icloud.com
 #

--- a/flash
+++ b/flash
@@ -488,9 +488,10 @@ add_datetime() {
   current_datetime=$(date -u)
 
   ed "$1" <<EOF
-  /^runcmd:/
+  /^bootcmd:.*/
   a
-  - date -s "$current_datetime"
+  - [ cloud-init-per, once, sdate_msg, echo, "Setting initial date/time to: $current_datetime" ]
+  - [ cloud-init-per, once, sdate, date, -s, "$current_datetime" ]
 .
 w
 q
@@ -680,12 +681,12 @@ mount_boot_disk "${disk}" "${boot}"
     echo "Copying cloud-init ${USER_DATA} to ${boot}/user-data ..."
     cp "${USER_DATA}" "${boot}/user-data"
     # Hack to set date in a reasonable range to make apt-get update work
-    if ! grep -q "^runcmd:" "${boot}"/user-data; then
-      # USER_DATA doesn't have a runcmd section, add it
+    if ! grep -q "^bootcmd:.*" "${boot}"/user-data; then
+      # USER_DATA doesn't have a bootcmd section, add it
       echo "" >> "${boot}"/user-data
-      echo "runcmd:" >> "${boot}"/user-data
+      echo "bootcmd:" >> "${boot}"/user-data
     fi
-    # Set date/time as first command in `runcmd` section
+    # Set date/time cloud-init `bootcmd` section
     add_datetime "${boot}"/user-data
   fi
 

--- a/flash
+++ b/flash
@@ -487,12 +487,11 @@ add_datetime() {
   # get current UTC date/time
   current_datetime=$(date -u)
 
-  /usr/bin/sed -i .bak -e \
+  sed_i -e \
   "/^bootcmd/a\\
-  \ \ - [ cloud-init-per, once, sdate_msg, echo, \"Setting initial date/time to: $current_datetime\" ]" \
-  -e "/^bootcmd/a\\
-  \ \ - [ cloud-init-per, once, sdate, date, -s, \"$current_datetime\" ]" "$1" &&
-  rm "$1".bak
+\ \ - [ cloud-init-per, once, sdate_msg, echo, \"Setting initial date/time to: $current_datetime\" ]" \
+ -e "/^bootcmd/a\\
+\ \ - [ cloud-init-per, once, sdate, date, -s, \"$current_datetime\" ]" "$1"
 }
 
 if endswith Microsoft "$(uname -r)"; then

--- a/flash
+++ b/flash
@@ -485,7 +485,7 @@ esac
 add_datetime() {
   # args: $1: full path name of `user-data` file on ssd
   # get current UTC date/time
-  current_datetime=$(date -u)
+  current_datetime=$(LANG=C date -u)
 
   sed_i -e \
   "/^bootcmd/a\\


### PR DESCRIPTION
As the Raspberry Pi's don't have a Real Time Clock (RTC), it takes
a while before `ntpd` sets the time to the current (real) time.
This creates a problem as `apt-get update` relies on the date/time
being not too far off the mark.
This commit will add a command as part of the `runcmd` section of
`cloud-init` that sets the date/time to the date/time at which the
`ssd` was flashed. Even though this will not set the date/time accurately,
the skew is small enough to make `apt-get update` work.