### PR TITLE
Check for WSL2

### DIFF
--- a/flash
+++ b/flash
@@ -482,8 +482,13 @@ case "${OSTYPE}" in
     ;;
 esac
 
+if endswith microsoft-standard "$(uname -r)"; then
+  echo This script does not work in WSL2.
+  exit 11
+fi
+
 if endswith Microsoft "$(uname -r)"; then
-  echo This script does not work in WSL.
+  echo This script does not work in WSL1.
   exit 11
 fi
 


### PR DESCRIPTION
Check for WSL2 kernels and show the user a message that `flash` is not supported in WSL1 and WSL2.

Refers to #160 