### PR TITLE
Make xz compression check case insensitive

### DIFF
--- a/flash
+++ b/flash
@@ -573,7 +573,7 @@ if [[ -z $CONFIGURE_ONLY ]] ; then
       echo "Use ${image}"
     fi
 
-    if [[ "$(file "${image}")" == *"xz compressed data"* ]]; then
+    if [[ "$(file "${image}" | tr '[:upper:]' '[:lower:]' )" == *"xz compressed data"* ]]; then
       command -v xz 2>/dev/null || error "Error: unzip not found. Aborting" 1
       echo "Uncompressing ${image} ..."
       xz -d "${image}" -c >/tmp/image.img


### PR DESCRIPTION
I tried to flash Ubuntu 64bit, but flash didn't extract the xz archive.

```file
$ file ~/Downloads/ubuntu-18.04.4-preinstalled-server-arm64+raspi3.img.xz
/Users/stefanscherer/Downloads/ubuntu-18.04.4-preinstalled-server-arm64+raspi3.img.xz: XZ compressed data
```

This PR makes the xz compression check case insensitive.
