### PR TITLE
Allow graceful period for all operations to complete before unmounting #169

### DIFF
--- a/flash
+++ b/flash
@@ -738,7 +738,7 @@ if [ -f "${boot}/occidentalis.txt" ]; then
 fi
 
 echo "Unmounting ${disk} ..."
-sleep 1
+sleep 5
 
 set +e
 detach "${disk}"


### PR DESCRIPTION
Fix: 
- #169 race condition of the copy operation wasn't completed and disk couldn't be unmounted

@StefanScherer please see the issue for more context.