### PR TITLE
Allow to download files related to cloud-init via http(s)

### DIFF
--- a/flash
+++ b/flash
@@ -494,7 +494,23 @@ fi
 
 check_requirements
 
+http_download() {
+  local uri="${1}"
+  local tmp="/tmp/${2}"
+
+  if beginswith http:// "${uri}" || beginswith https:// "${uri}"; then
+    command -v curl 2>/dev/null || error "Error: curl not found. Aborting" 1
+    echo "Downloading ${uri} ..."
+    curl -L --fail -o "${tmp}" "${uri}"
+    _RET="${tmp}"
+  else
+    _RET="${uri}"
+  fi
+}
+
 if [ -n "${USER_DATA}" ]; then
+  http_download "$USER_DATA" "flash.user_data.yaml"
+  USER_DATA="$_RET"
   if [ ! -f "${USER_DATA}" ]; then
     echo "Cloud-init file ${USER_DATA} not found!"
     exit 10
@@ -503,6 +519,8 @@ if [ -n "${USER_DATA}" ]; then
 fi
 
 if [ -n "${META_DATA}" ]; then
+  http_download "$META_DATA" "flash.meta_data.yaml"
+  META_DATA="$_RET"
   if [ ! -f "${META_DATA}" ]; then
     echo "Cloud-init file ${META_DATA} not found!"
     exit 10
@@ -510,6 +528,8 @@ if [ -n "${META_DATA}" ]; then
 fi
 
 if [ -n "${FILE}" ]; then
+  http_download "$FILE" "flash.file"
+  FILE="$_RET"
   if [ ! -f "${FILE}" ]; then
     echo "File ${FILE} not found!"
     exit 10
@@ -517,6 +537,8 @@ if [ -n "${FILE}" ]; then
 fi
 
 if [ -n "${BOOT_CONF}" ]; then
+  http_download "$BOOT_CONF" "flash.config.txt"
+  BOOT_CONF="$_RET"
   if [ ! -f "${BOOT_CONF}" ]; then
     echo "File ${BOOT_CONF} not found!"
     exit 10
@@ -524,6 +546,8 @@ if [ -n "${BOOT_CONF}" ]; then
 fi
 
 if [ -n "${CONFIG_FILE}" ]; then
+  http_download "$CONFIG_FILE" "flash.device_init.yaml"
+  CONFIG_FILE="$_RET"
   if [ ! -f "${CONFIG_FILE}" ]; then
     echo "File ${CONFIG_FILE} not found!"
     exit 10

--- a/test/cloud-init.bats
+++ b/test/cloud-init.bats
@@ -202,7 +202,7 @@ teardown() {
 }
 
 @test "cloud-init: flash --metadata can be downloaded" {
-  run ./flash -f -d $img --userdata https://raw.githubusercontent.com/hypriot/flash/master/test/resources/meta.yml cloud-init.img
+  run ./flash -f -d $img --userdata test/resources/good.yml --metadata https://raw.githubusercontent.com/hypriot/flash/master/test/resources/meta.yml cloud-init.img
   assert_success
   assert_output_contains Downloading
   assert_output_contains Finished.

--- a/test/cloud-init.bats
+++ b/test/cloud-init.bats
@@ -184,3 +184,42 @@ teardown() {
   run cat /tmp/boot/config.txt
   assert_output_contains "enable_uart=0"
 }
+
+@test "cloud-init: flash --userdata can be downloaded" {
+  run ./flash -f -d $img --userdata https://raw.githubusercontent.com/hypriot/flash/master/test/resources/good.yml cloud-init.img
+  assert_success
+  assert_output_contains Downloading
+  assert_output_contains Finished.
+
+  mount_sd_boot $img /tmp/boot
+  run cat /tmp/boot/user-data
+  assert_output_contains "hostname: good"
+  assert_output_contains "name: other"
+  assert_output_contains "ssh-authorized-keys:"
+
+  assert [ -e "/tmp/boot/meta-data" ]
+  assert [ ! -s "/tmp/boot/meta-data" ]
+}
+
+@test "cloud-init: flash --metadata can be downloaded" {
+  run ./flash -f -d $img --userdata https://raw.githubusercontent.com/hypriot/flash/master/test/resources/meta.yml cloud-init.img
+  assert_success
+  assert_output_contains Downloading
+  assert_output_contains Finished.
+
+  mount_sd_boot $img /tmp/boot
+  run cat /tmp/boot/user-data
+  assert_output_contains "hostname: good"
+  assert_output_contains "name: other"
+  assert_output_contains "ssh-authorized-keys:"
+
+  run cat /tmp/boot/meta-data
+  assert_output_contains "instance-id: iid-local01"
+}
+
+@test "cloud-init: flash --userdata aborts on 'not found' (404)" {
+  run ./flash -f -d $img --userdata https://raw.githubusercontent.com/hypriot/flash/master/test/resources/foo.bar cloud-init.img
+  assert_failure
+
+  assert_output_contains "The requested URL returned error: 404 Not Found"
+}


### PR DESCRIPTION
With this URLs can be specified instead of local files for `--bootconf`, `--config`, `--userdata`, `--metadata` and `--file`.