### PR TITLE
Feature/improve drive id retrieval

### DIFF
--- a/flash
+++ b/flash
@@ -219,7 +219,9 @@ case "${OSTYPE}" in
     # @param arg1 the name of the device holding the volume to be mounted
     # @return _RET mount point name
     get_boot_mount_point() {
-      _RET=$(df | grep --color=never "${1}s1" | /usr/bin/sed 's,.*/Volumes,/Volumes,')
+      local device_id="${1}"
+      local disk_id=$(mount | grep "${device_id}" | grep msdos | cut -f1 -d' ')
+      _RET=$(df | grep --color=never "${disk_id}" | /usr/bin/sed 's,.*/Volumes,/Volumes,')
     }
 
     # Wait for the new created disk to be available

--- a/flash
+++ b/flash
@@ -416,15 +416,10 @@ case "${OSTYPE}" in
     #
     # @param arg1 the disk name containing the partition
     find_boot_dev_name() {
-      if beginswith /dev/mmcblk "${1}" ;then
-        _RET="${1}p1"
-      elif beginswith /dev/loop "${1}" ;then
-        _RET="${1}p1"
-      else
-        _RET="${1}1"
-      fi
+      local device_id="${1}"
+      local disk_id=$(sudo fdisk "${device_id}" -l -o device,type 2>/dev/null | grep "Microsoft" | head -n 1 | cut -f1 -d' ')
+      _RET="${disk_id}"
     }
-
 
     # Unmount a disk
     #


### PR DESCRIPTION
I am using hypriot flash utility to flash hypriot images, but also other other images, for which the 'FAT' partition is not always the first one: for instance, the disk image for the rock-64 arm device (https://github.com/ayufan-rock64/linux-build/releases/download/0.8.3/bionic-minimal-rock64-0.8.3-1141-arm64.img.xz) has 7 partitions, and the FAT partition is number 6.
Therefore, I have improved the way to retrieve this partition id (I search for the first MSDOS partition). I did some successful test on linux and on mac (but of course, not with every possible situation).
I will be happy to see this code in a next official hypriot/flash release. 