### PR TITLE
copy multiple custom files to /boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ OPTIONS:
    --force|-f     Force flash without security prompt (for automation)
    --userdata|-u  Copy this cloud-init config file to /boot/user-data
    --metadata|-m  Copy this cloud-init config file to /boot/meta-data
-   --file|-F      Copy this custom file to /boot
+   --file|-F      Copy this file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
 ```
 
 ## Configuration
@@ -204,6 +204,16 @@ For non-interactive usage, you can predefine the user input in the flash command
 ```
 flash -d /dev/mmcblk0 -f hypriotos-rpi-v1.12.0.img
 ```
+
+### Copying multiple custom files to /boot
+
+The option `-F/--file` can be used multiple times to copy some extra files to /boot after flashing the image, e.g.:
+
+```
+flash --file note1.txt --file note2.txt hypriotos-rpi-v1.12.0.img
+```
+
+In this example, both note1.txt and note2.txt will be available in /boot.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ OPTIONS:
    --force|-f     Force flash without security prompt (for automation)
    --userdata|-u  Copy this cloud-init config file to /boot/user-data
    --metadata|-m  Copy this cloud-init config file to /boot/meta-data
-   --file|-F      Copy this file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
+   --file|-F      Copy this custom file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
 ```
 
 ## Configuration

--- a/flash
+++ b/flash
@@ -105,7 +105,7 @@ while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:" opt; do
     f)  FORCE=1 ;;
     u)  USER_DATA=$OPTARG ;;
     m)  META_DATA=$OPTARG ;;
-    F)  EXTRA_FILES+=($OPTARG) ;;
+    F)  EXTRA_FILES+=("$OPTARG") ;;
     \?) usage ;;
     :)
       echo "option -$OPTARG requires an argument"

--- a/flash
+++ b/flash
@@ -38,7 +38,7 @@ OPTIONS:
   --force|-f      Force flash without security prompt (for automation)
   --userdata|-u   Copy this cloud-init file to /boot/user-data
   --metadata|-m   Copy this cloud-init file to /boot/meta-data
-  --file|-F       Copy this file to /boot
+  --file|-F       Copy this file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
 
 If no image is specified, the script will try to configure an existing
 image. This is useful to try several configuration without the need to

--- a/flash
+++ b/flash
@@ -38,7 +38,7 @@ OPTIONS:
   --force|-f      Force flash without security prompt (for automation)
   --userdata|-u   Copy this cloud-init file to /boot/user-data
   --metadata|-m   Copy this cloud-init file to /boot/meta-data
-  --file|-F       Copy this file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
+  --file|-F       Copy this custom file to /boot, use this flag multiple times to copy multiple files (e.g. flash --file note1.txt --file note2.txt ...)
 
 If no image is specified, the script will try to configure an existing
 image. This is useful to try several configuration without the need to

--- a/flash
+++ b/flash
@@ -63,6 +63,8 @@ EOF
   exit 1
 }
 
+declare -a EXTRA_FILES
+
 # translate long options to short
 for arg
 do
@@ -103,7 +105,7 @@ while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:" opt; do
     f)  FORCE=1 ;;
     u)  USER_DATA=$OPTARG ;;
     m)  META_DATA=$OPTARG ;;
-    F)  FILE=$OPTARG ;;
+    F)  EXTRA_FILES+=($OPTARG) ;;
     \?) usage ;;
     :)
       echo "option -$OPTARG requires an argument"
@@ -538,14 +540,14 @@ if [ -n "${META_DATA}" ]; then
   fi
 fi
 
-if [ -n "${FILE}" ]; then
-  http_download "$FILE" "flash.file"
-  FILE="$_RET"
-  if [ ! -f "${FILE}" ]; then
-    echo "File ${FILE} not found!"
+for index in "${!EXTRA_FILES[@]}"; do 
+  http_download "${EXTRA_FILES[$index]}" "flash.file.$index" 
+  EXTRA_FILES[$index]="$_RET"
+  if [ ! -f "${EXTRA_FILES[$index]}" ]; then
+    echo "File ${EXTRA_FILES[$index]} not found!"
     exit 10
   fi
-fi
+done
 
 if [ -n "${BOOT_CONF}" ]; then
   http_download "$BOOT_CONF" "flash.config.txt"
@@ -711,10 +713,10 @@ mount_boot_disk "${disk}" "${boot}"
     cp "${META_DATA}" "${boot}/meta-data"
   fi
 
-  if [ -f "${FILE}" ]; then
-    echo "Copying file ${FILE} to ${boot}/ ..."
-    cp "${FILE}" "${boot}/"
-  fi
+  for i in "${EXTRA_FILES[@]}"; do 
+    echo "Copying file ${i} to ${boot}/ ..."
+    cp "${i}" "${boot}/"
+  done
 
 if [ -f "${boot}/device-init.yaml" ]; then
   echo "Setting device-init"

--- a/test/multiple-custom-files.bats
+++ b/test/multiple-custom-files.bats
@@ -1,0 +1,32 @@
+load test_helper
+export OS=$(uname -s)
+
+setup() {
+  if [ ! -f cloud-init.img ]; then
+    # download SD card image with cloud-init
+    curl -L -o download.img.zip https://github.com/hypriot/image-builder-rpi/releases/download/v1.7.1/hypriotos-rpi-v1.7.1.img.zip
+    unzip download.img.zip
+    # cut only 70 MByte to flash faster
+    dd if=hypriotos-rpi-v1.7.1.img of=cloud-init.img bs=1048576 count=70
+  fi
+  stub_diskutil
+}
+
+teardown() {
+  umount_sd_boot /tmp/boot
+  rm -f $img
+  unstub_diskutil
+}
+
+@test "copying multiple files" {
+  run ./flash -f -d $img --file test/resources/note1.txt --file test/resources/note2.txt cloud-init.img
+  assert_success
+  assert_output_contains Finished.
+
+  mount_sd_boot $img /tmp/boot
+  run cat /tmp/boot/note1.txt
+  assert_output_contains "lorem ipsum"
+
+  run cat /tmp/boot/note2.txt
+  assert_output_contains "hello world"
+}

--- a/test/resources/note1.txt
+++ b/test/resources/note1.txt
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/test/resources/note2.txt
+++ b/test/resources/note2.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
I'm using this flash utility to write raspian and ubuntu images but I would like to copy multiple custom files to /boot.
This pull request adds the ability to do this with multiple `-F/--file` flags like: `flash --file usercfg.txt --file network-config ... `