### PR TITLE
Add further options to customize files after flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,21 @@ usage: flash [options] [name-of-rpi.img]
 Flash a local or remote Raspberry Pi SD card image.
 
 OPTIONS:
-   --help|-h      Show this message
-   --bootconf|-C  Copy this config file to /boot/config.txt
-   --config|-c    Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
-   --hostname|-n  Set hostname for this SD image
-   --ssid|-s      Set WiFi SSID for this SD image
-   --password|-p  Set WiFI password for this SD image
-   --clusterlab|-l Start Cluster-Lab on boot: true or false
-   --device|-d    Card device to flash to (e.g. /dev/disk2)
-   --force|-f     Force flash without security prompt (for automation)
-   --userdata|-u  Copy this cloud-init config file to /boot/user-data
-   --metadata|-m  Copy this cloud-init config file to /boot/meta-data
-   --file|-F      Copy this custom file to /boot
+  --help|-h          Show this message
+  --bootconf|-C      Copy this config file to /boot/config.txt
+  --bootuserconf|-U  Copy this config file to /boot/usercfg.txt
+  --config|-c        Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
+  --hostname|-n      Set hostname for this SD image
+  --ssid|-s          Set WiFi SSID for this SD image
+  --password|-p      Set WiFI password for this SD image
+  --clusterlab|-l    Start Cluster-Lab on boot: true or false
+  --device|-d        Card device to flash to (e.g. /dev/sdb in Linux or /dev/disk2 in OSX)
+  --force|-f         Force flash without security prompt (for automation)
+  --userdata|-u      Copy this cloud-init user-data file to /boot/user-data
+  --metadata|-m      Copy this cloud-init meta-data file to /boot/meta-data
+  --networkconfig|-N Copy this cloud-init network-config file to /boot/network-config
+  --file|-F          Copy this file to /boot
+  --cmdline|-L       Copy this cmdline.txt to /boot/cmdline.txt
 ```
 
 ## Configuration
@@ -99,7 +102,7 @@ The strength of the flash tool is that it can insert some configuration files th
 
 ### cloud-init
 
-With HypriotOS v1.7.0 and higher the options `--userdata` and `--metadata` can be used to copy both cloud-init config files into the FAT partition.
+With HypriotOS v1.7.0 and higher the options `--userdata`, `--metadata` and `--networkconfig` can be used to copy the cloud-init config files `user-data`, `meta-data` and `network-config` respectively into the FAT partition. 
 
 This is an example how to create our default user with a password.
 
@@ -127,10 +130,11 @@ package_upgrade: false
 Please have a look at the [`sample`](sample/) folder, our guest blogpost [Bootstrapping a Cloud with Cloud-Init and HypriotOS](https://blog.hypriot.com/post/cloud-init-cloud-on-hypriot-x64/) or at the [cloud-init documentation](http://cloudinit.readthedocs.io/en/0.7.9/)
 how to do more things like using SSH keys, running additional commands etc.
 
-### config.txt
+### config.txt, usercfg.txt
 
 The option `--bootconf` can be used to copy a `config.txt` into the SD image
-before it is unplugged.
+before it is unplugged. The option `--bootuserconf` copies a `usercfg.txt` and should be 
+used instead on distributions using a modular `config.txt` like Ubuntu.
 
 With this option it is possible to change some memory, camera, video settings
 etc. See the [config.txt documentation](https://www.raspberrypi.org/documentation/configuration/config-txt/README.md)
@@ -142,6 +146,10 @@ The boot config file config.txt has name/value pairs such as:
 max_usb_current=1
 hdmi_force_hotplug=1
 ```
+
+### cmdline.txt
+
+The option `--cmdline` can be used to copy a `cmdline.txt` to the SD image and e.g. modify kernel boot parameters.
 
 ### device-init.yaml
 

--- a/flash
+++ b/flash
@@ -39,8 +39,8 @@ OPTIONS:
   --force|-f         Force flash without security prompt (for automation)
   --userdata|-u      Copy this cloud-init user-data file to /boot/user-data
   --metadata|-m      Copy this cloud-init meta-data file to /boot/meta-data
+  --networkconfig|-N Copy this cloud-init network-config file to /boot/network-config
   --file|-F          Copy this file to /boot
-  --networkconfig|-N Copy this cloud-init network-config to /boot/network-config
   --cmdline|-L       Copy this cmdline.txt to /boot/cmdline.txt
 
 If no image is specified, the script will try to configure an existing
@@ -84,8 +84,8 @@ do
     --force) args="${args}-f ";;
     --userdata) args="${args}-u ";;
     --metadata) args="${args}-m ";;
-    --file) args="${args}-F ";;
     --networkconfig) args="${args}-N ";;
+    --file) args="${args}-F ";;
     --cmdline) args="${args}-L ";;
     # pass through anything else
     *) [[ "${arg:0:1}" == "-" ]] || delim="\""
@@ -110,8 +110,8 @@ while getopts ":h:vc:n:s:p:C:U:l:d:fu:m:F:N:L:" opt; do
     f)  FORCE=1 ;;
     u)  USER_DATA=$OPTARG ;;
     m)  META_DATA=$OPTARG ;;
-    F)  FILE=$OPTARG ;;
     N)  NETWORK_CONFIG=$OPTARG ;;
+    F)  FILE=$OPTARG ;;
     L)  CMD_LINE=$OPTARG ;;
     \?) usage ;;
     :)

--- a/flash
+++ b/flash
@@ -27,18 +27,20 @@ usage: $0 [options] [name-of-rpi.img]
 Flash a local or remote Raspberry Pi SD card image.
 
 OPTIONS:
-  --help|-h       Show this message
-  --bootconf|-C   Copy this config file to /boot/config.txt
-  --config|-c     Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
-  --hostname|-n   Set hostname for this SD image
-  --ssid|-s       Set WiFi SSID for this SD image
-  --password|-p   Set WiFI password for this SD image
-  --clusterlab|-l Start Cluster-Lab on boot: true or false
-  --device|-d     Card device to flash to (e.g. /dev/sdb in Linux or /dev/disk2 in OSX)
-  --force|-f      Force flash without security prompt (for automation)
-  --userdata|-u   Copy this cloud-init file to /boot/user-data
-  --metadata|-m   Copy this cloud-init file to /boot/meta-data
-  --file|-F       Copy this file to /boot
+  --help|-h          Show this message
+  --bootconf|-C      Copy this config file to /boot/config.txt
+  --config|-c        Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
+  --hostname|-n      Set hostname for this SD image
+  --ssid|-s          Set WiFi SSID for this SD image
+  --password|-p      Set WiFI password for this SD image
+  --clusterlab|-l    Start Cluster-Lab on boot: true or false
+  --device|-d        Card device to flash to (e.g. /dev/sdb in Linux or /dev/disk2 in OSX)
+  --force|-f         Force flash without security prompt (for automation)
+  --userdata|-u      Copy this cloud-init user-data file to /boot/user-data
+  --metadata|-m      Copy this cloud-init meta-data file to /boot/meta-data
+  --file|-F          Copy this file to /boot
+  --networkconfig|-N Copy this cloud-init network-config to /boot/network-config
+  --cmdline|-L       Copy this cmdline.txt to /boot/cmdline.txt
 
 If no image is specified, the script will try to configure an existing
 image. This is useful to try several configuration without the need to
@@ -81,6 +83,8 @@ do
     --userdata) args="${args}-u ";;
     --metadata) args="${args}-m ";;
     --file) args="${args}-F ";;
+    --networkconfig) args="${args}-N ";;
+    --cmdline) args="${args}-L ";;
     # pass through anything else
     *) [[ "${arg:0:1}" == "-" ]] || delim="\""
       args="${args}${delim}${arg}${delim} ";;
@@ -89,7 +93,7 @@ done
 # reset the translated args
 eval set -- "$args"
 # now we can process with getopt
-while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:" opt; do
+while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:N:L:" opt; do
   case $opt in
     h)  usage ;;
     v)  version ;;
@@ -104,6 +108,8 @@ while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:" opt; do
     u)  USER_DATA=$OPTARG ;;
     m)  META_DATA=$OPTARG ;;
     F)  FILE=$OPTARG ;;
+    N)  NETWORK_CONFIG=$OPTARG ;;
+    L)  CMD_LINE=$OPTARG ;;
     \?) usage ;;
     :)
       echo "option -$OPTARG requires an argument"
@@ -538,6 +544,24 @@ if [ -n "${META_DATA}" ]; then
   fi
 fi
 
+if [ -n "${NETWORK_CONFIG}" ]; then
+  http_download "$NETWORK_CONFIG" "flash.network_config.yaml"
+  NETWORK_CONFIG="$_RET"
+  if [ ! -f "${NETWORK_CONFIG}" ]; then
+    echo "Cloud-init file ${NETWORK_CONFIG} not found!"
+    exit 10
+  fi
+fi
+
+if [ -n "${CMD_LINE}" ]; then
+  http_download "$CMD_LINE" "flash.cmdline.txt"
+  CMD_LINE="$_RET"
+  if [ ! -f "${CMD_LINE}" ]; then
+    echo "cmdline file ${CMD_LINE} not found!"
+    exit 10
+  fi
+fi
+
 if [ -n "${FILE}" ]; then
   http_download "$FILE" "flash.file"
   FILE="$_RET"
@@ -709,6 +733,16 @@ mount_boot_disk "${disk}" "${boot}"
   if [ -f "${META_DATA}" ]; then
     echo "Copying cloud-init ${META_DATA} to ${boot}/meta-data ..."
     cp "${META_DATA}" "${boot}/meta-data"
+  fi
+
+  if [ -f "${NETWORK_CONFIG}" ]; then
+    echo "Copying cloud-init ${NETWORK_CONFIG} to ${boot}/network-config ..."
+    cp "${NETWORK_CONFIG}" "${boot}/network-config"
+  fi
+
+  if [ -f "${CMD_LINE}" ]; then
+    echo "Copying ${CMD_LINE} to ${boot}/cmdline.txt ..."
+    cp "${CMD_LINE}" "${boot}/cmdline.txt"
   fi
 
   if [ -f "${FILE}" ]; then

--- a/flash
+++ b/flash
@@ -29,6 +29,7 @@ Flash a local or remote Raspberry Pi SD card image.
 OPTIONS:
   --help|-h          Show this message
   --bootconf|-C      Copy this config file to /boot/config.txt
+  --bootuserconf|-U  Copy this config file to /boot/usercfg.txt
   --config|-c        Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
   --hostname|-n      Set hostname for this SD image
   --ssid|-s          Set WiFi SSID for this SD image
@@ -77,6 +78,7 @@ do
     --ssid) args="${args}-s ";;
     --password) args="${args}-p ";;
     --bootconf) args="${args}-C ";;
+    --bootuserconf) args="${args}-U ";;
     --clusterlab) args="${args}-l ";;
     --device) args="${args}-d ";;
     --force) args="${args}-f ";;
@@ -93,12 +95,13 @@ done
 # reset the translated args
 eval set -- "$args"
 # now we can process with getopt
-while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:N:L:" opt; do
+while getopts ":h:vc:n:s:p:C:U:l:d:fu:m:F:N:L:" opt; do
   case $opt in
     h)  usage ;;
     v)  version ;;
     c)  CONFIG_FILE=$OPTARG ;;
     C)  BOOT_CONF=$OPTARG ;;
+    U)  BOOT_USER_CONF=$OPTARG ;;
     n)  SD_HOSTNAME=$OPTARG ;;
     s)  WIFI_SSID=$OPTARG ;;
     p)  WIFI_PASSWORD=$OPTARG ;;
@@ -581,6 +584,15 @@ if [ -n "${BOOT_CONF}" ]; then
   fi
 fi
 
+if [ -n "${BOOT_USER_CONF}" ]; then
+  http_download "$BOOT_USER_CONF" "flash.usercfg.txt"
+  BOOT_USER_CONF="$_RET"
+  if [ ! -f "${BOOT_USER_CONF}" ]; then
+    echo "File ${BOOT_USER_CONF} not found!"
+    exit 10
+  fi
+fi
+
 if [ -n "${CONFIG_FILE}" ]; then
   http_download "$CONFIG_FILE" "flash.device_init.yaml"
   CONFIG_FILE="$_RET"
@@ -724,6 +736,11 @@ mount_boot_disk "${disk}" "${boot}"
   if [[ -f "${BOOT_CONF}" ]]; then
     echo "Copying ${BOOT_CONF} to ${boot}/config.txt ..."
     cp "${BOOT_CONF}" "${boot}/config.txt"
+  fi
+
+  if [[ -f "${BOOT_USER_CONF}" ]]; then
+    echo "Copying ${BOOT_USER_CONF} to ${boot}/usercfg.txt ..."
+    cp "${BOOT_USER_CONF}" "${boot}/usercfg.txt"
   fi
 
   if [ -f "${USER_DATA}" ]; then

--- a/flash
+++ b/flash
@@ -189,7 +189,7 @@ case "${OSTYPE}" in
           _RET=/dev/$(diskutil list | grep --color=never FDisk_partition_scheme | awk 'NF>1{print $NF}')
         done
       fi
-      diskutil list $_RET
+      diskutil list "${_RET}"
       set -e
     }
 

--- a/flash
+++ b/flash
@@ -186,6 +186,7 @@ case "${OSTYPE}" in
           _RET=/dev/$(diskutil list | grep --color=never FDisk_partition_scheme | awk 'NF>1{print $NF}')
         done
       fi
+      diskutil list $_RET
       set -e
     }
 


### PR DESCRIPTION
This MR adds options to copy custom files for 

- cloud-init `network-config`
- `cmdline.txt`
- `usercfg.txt` for distributions having "modular" config.txt/syscfg.txt/usercfg.txt instead of only `config.txt` (e.g. Ubuntu)

Another small addition sneaked in: display information on the auto-detected flash card device node before asking if it's the right one (MacOS only).