### PR TITLE
Fix for macos Big Sur changes to diskutil output

### DIFF
--- a/flash
+++ b/flash
@@ -200,7 +200,7 @@ case "${OSTYPE}" in
         _RET=1
         return
       fi
-      readonlymedia=$(diskutil info "$disk" | grep --color=never "Read-Only Media" | awk 'NF>1{print $NF}')
+      readonlymedia=$(diskutil info "$disk" | grep --color=never "Read-Only Media\|Media Read-Only" | awk 'NF>1{print $NF}')
       if [[ $readonlymedia == "No" ]] ; then
         _RET=1
       else


### PR DESCRIPTION
macos' "diskutil" reported "Read-Only Media: No" up until v10.6, but v11.0 (Big Sur) reports the same information as "Media Read-Only: No". This commit adds support for both variants.