### PR TITLE
Fix for hdparm error: BLKRRPART failed ...

### DIFF
--- a/flash
+++ b/flash
@@ -418,7 +418,9 @@ case "${OSTYPE}" in
     wait_for_disk() {
       echo "Waiting for device $1"
       udevadm settle
-      sudo hdparm -z "$1"
+      while : ; do
+        sudo hdparm -z "$1" && break
+      done
     }
 
     # Find the device name of the boot partition


### PR DESCRIPTION
'hdparm -z' failed on about 80% of attempts with error:
    BLKRRPART failed: Device or resource busy

A simple 'sync' before it did not help, but with this loop the second
execution does the job.