### PR TITLE
Append arguments to /boot/cmdline.txt

### DIFF
--- a/flash
+++ b/flash
@@ -27,18 +27,19 @@ usage: $0 [options] [name-of-rpi.img]
 Flash a local or remote Raspberry Pi SD card image.
 
 OPTIONS:
-  --help|-h       Show this message
-  --bootconf|-C   Copy this config file to /boot/config.txt
-  --config|-c     Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
-  --hostname|-n   Set hostname for this SD image
-  --ssid|-s       Set WiFi SSID for this SD image
-  --password|-p   Set WiFI password for this SD image
-  --clusterlab|-l Start Cluster-Lab on boot: true or false
-  --device|-d     Card device to flash to (e.g. /dev/sdb in Linux or /dev/disk2 in OSX)
-  --force|-f      Force flash without security prompt (for automation)
-  --userdata|-u   Copy this cloud-init file to /boot/user-data
-  --metadata|-m   Copy this cloud-init file to /boot/meta-data
-  --file|-F       Copy this file to /boot
+  --help|-h        Show this message
+  --bootconf|-C    Copy this config file to /boot/config.txt
+  --cmdlineargs|-A Append arguments to /boot/cmdline.txt
+  --config|-c      Copy this config file to /boot/device-init.yaml (or occidentalis.txt)
+  --hostname|-n    Set hostname for this SD image
+  --ssid|-s        Set WiFi SSID for this SD image
+  --password|-p    Set WiFI password for this SD image
+  --clusterlab|-l  Start Cluster-Lab on boot: true or false
+  --device|-d      Card device to flash to (e.g. /dev/sdb in Linux or /dev/disk2 in OSX)
+  --force|-f       Force flash without security prompt (for automation)
+  --userdata|-u    Copy this cloud-init file to /boot/user-data
+  --metadata|-m    Copy this cloud-init file to /boot/meta-data
+  --file|-F        Copy this file to /boot
 
 If no image is specified, the script will try to configure an existing
 image. This is useful to try several configuration without the need to
@@ -75,6 +76,7 @@ do
     --ssid) args="${args}-s ";;
     --password) args="${args}-p ";;
     --bootconf) args="${args}-C ";;
+    --cmdlineargs) args="${args}-A ";;
     --clusterlab) args="${args}-l ";;
     --device) args="${args}-d ";;
     --force) args="${args}-f ";;
@@ -89,12 +91,13 @@ done
 # reset the translated args
 eval set -- "$args"
 # now we can process with getopt
-while getopts ":h:vc:n:s:p:C:l:d:fu:m:F:" opt; do
+while getopts ":h:vc:n:s:p:C:A:l:d:fu:m:F:" opt; do
   case $opt in
     h)  usage ;;
     v)  version ;;
     c)  CONFIG_FILE=$OPTARG ;;
     C)  BOOT_CONF=$OPTARG ;;
+    A)  CMDLINE_ARGS=$OPTARG ;;
     n)  SD_HOSTNAME=$OPTARG ;;
     s)  WIFI_SSID=$OPTARG ;;
     p)  WIFI_PASSWORD=$OPTARG ;;
@@ -779,6 +782,11 @@ if [ -f "${boot}/occidentalis.txt" ]; then
     sed_i -e "s/.*wifi_password.*=.*\$/wifi_password=${WIFI_PASSWORD}/" "${boot}/occidentalis.txt"
   fi
 fi
+
+  if [ -n "${CMDLINE_ARGS}" ]; then
+    echo "  Append ${CMDLINE_ARGS} to cmdline.txt"
+    sed_i -e "s/^\(.*\)\$/\1 ${CMDLINE_ARGS}/" "${boot}/cmdline.txt"
+  fi
 
 echo "Unmounting ${disk} ..."
 sleep 5


### PR DESCRIPTION
It might be interesting in some scenarii to add extra parameters to /boot/cmdline.txt, for instance `cgroup_enable=memory cgroup_memory=1` to enable docker on R-pi.

The new feature proposes `--cmdlineargs` arguments to `flash` to achieve this exact goal. 